### PR TITLE
CI_DATA_MIGRATION, change docker port mapping for CI_DATA_MIGRATION i…

### DIFF
--- a/src/main/resources/docker/docker-compose.yml
+++ b/src/main/resources/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./data/mysql:/var/lib/mysql
     ports:
-      - "3306:3306"
+      - "3307:3306"
 
   server:
     image: partnersinhealth/openmrs-server:latest
@@ -27,7 +27,7 @@ services:
       - ./distribution:/openmrs/distribution
       - openmrs-data:/openmrs/data
     ports:
-      - "8080:8080"
+      - "8081:8080"
 
 volumes:
   openmrs-data:


### PR DESCRIPTION
…nstance

Hi @mseaton and @jmbabazi , does this small change make sense to you? THis port mapping would be for the docker compose instance that we use to test the data migration from 1.x to 2.3. 
So in the [run-migration](https://github.com/PIH/rwandaemr-installer/blob/master/src/main/resources/scripts/run-migration.sh#L100) script we would download the CI_DATA_MIGRATION branch of this file. Let me know if you want to change the name of this branch or if it is a better technique to configure those docker ports. Thanks.
